### PR TITLE
Upgrade JWT Package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "phpseclib/phpseclib": "~2.0",
         "google/cloud-tasks": "^1.10",
         "thecodingmachine/safe": "^1.0|^2.0",
-        "firebase/php-jwt": "^5.0"
+        "firebase/php-jwt": "^5.5||^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",


### PR DESCRIPTION
This old version needs to be upgraded to avoid problems with other dependencies like Laravel Passport.